### PR TITLE
feat: add roles_path config

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 host_key_checking = False
 collections_paths = .
+roles_path = ./ansible_roles
 stdout_callback = yaml
 hash_behaviour = merge


### PR DESCRIPTION
### Linked issues

- Fixes #16 

### Changes

- Configure Ansible to store the roles in the current folder
