### PR TITLE
feat(vagrant): forward AvalancheGo HTTP port

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,8 @@ Vagrant.configure("2") do |config|
   # Define VMs
   machines.each_with_index do |(name, props), i|
     config.vm.define "#{name}-local".to_sym do |node|
-      node.vm.network :private_network, ip: props[:ip]
+      node.vm.network "private_network", ip: props[:ip]
+      node.vm.network "forwarded_port", guest: 9650, host: 9661 + i
       node.vm.hostname = "#{name}.local" 
       node.vm.provider "virtualbox" do |n|
         n.name =  "#{name}.local"

--- a/inventories/local/hosts
+++ b/inventories/local/hosts
@@ -1,11 +1,11 @@
 # Copyright (C) 2022, Gauthier Leonard
 # See the file LICENSE for licensing terms.
 
-validator01 ansible_host=192.168.60.11 avalanchego_http_host=192.168.60.11 ansible_user=vagrant ansible_ssh_private_key_file=./.vagrant/machines/validator01-local/virtualbox/private_key
-validator02 ansible_host=192.168.60.12 avalanchego_http_host=192.168.60.12 ansible_user=vagrant ansible_ssh_private_key_file=./.vagrant/machines/validator02-local/virtualbox/private_key
-validator03 ansible_host=192.168.60.13 avalanchego_http_host=192.168.60.13 ansible_user=vagrant ansible_ssh_private_key_file=./.vagrant/machines/validator03-local/virtualbox/private_key
-validator04 ansible_host=192.168.60.14 avalanchego_http_host=192.168.60.14 ansible_user=vagrant ansible_ssh_private_key_file=./.vagrant/machines/validator04-local/virtualbox/private_key
-validator05 ansible_host=192.168.60.15 avalanchego_http_host=192.168.60.15 ansible_user=vagrant ansible_ssh_private_key_file=./.vagrant/machines/validator05-local/virtualbox/private_key
+validator01 ansible_host=192.168.60.11 avalanchego_http_host=0.0.0.0 ansible_user=vagrant ansible_ssh_private_key_file=./.vagrant/machines/validator01-local/virtualbox/private_key
+validator02 ansible_host=192.168.60.12 avalanchego_http_host=0.0.0.0 ansible_user=vagrant ansible_ssh_private_key_file=./.vagrant/machines/validator02-local/virtualbox/private_key
+validator03 ansible_host=192.168.60.13 avalanchego_http_host=0.0.0.0 ansible_user=vagrant ansible_ssh_private_key_file=./.vagrant/machines/validator03-local/virtualbox/private_key
+validator04 ansible_host=192.168.60.14 avalanchego_http_host=0.0.0.0 ansible_user=vagrant ansible_ssh_private_key_file=./.vagrant/machines/validator04-local/virtualbox/private_key
+validator05 ansible_host=192.168.60.15 avalanchego_http_host=0.0.0.0 ansible_user=vagrant ansible_ssh_private_key_file=./.vagrant/machines/validator05-local/virtualbox/private_key
 frontend ansible_host=192.168.60.19 ansible_user=vagrant ansible_ssh_private_key_file=./.vagrant/machines/frontend-local/virtualbox/private_key
 
 [avalanche_nodes]


### PR DESCRIPTION
### Changes

- Vagrant
  - Forward AvalancheGo HTTP ports to `127.0.0.1:966[1:5]`
- Ansible
  - Use `avalanchego_http_host=0.0.0.0` to allow connecting through port forwarding