### PR TITLE
feat: add subnet_validator_params example

### DIFF
--- a/inventories/local/group_vars/avalanche_nodes.yml
+++ b/inventories/local/group_vars/avalanche_nodes.yml
@@ -16,8 +16,6 @@ avalanchego_vms_install: []
 avalanchego_track_subnets: []
 
 avalanchego_node_json:
-  # Adapt Snow consensus parameters to a 5-node network
-  snow-sample-size: 3
-  snow-quorum-size: 2
-  snow-mixed-query-num-push-vdr: 2
   http-allowed-hosts: "*"
+
+validator_stake_or_weight: 100

--- a/inventories/local/group_vars/blockscout.yml
+++ b/inventories/local/group_vars/blockscout.yml
@@ -1,6 +1,6 @@
 ---
-blockchain_id: 2dEmExGjJT6MouJRr1PqV4PSQEbScDAjKuPtT6pgqYR5xdUuac
+blockscout_blockchain_id: 2dEmExGjJT6MouJRr1PqV4PSQEbScDAjKuPtT6pgqYR5xdUuac
 
-blockscout_rpc: "http://{{ hostvars['validator01'].ansible_host }}:9650/ext/bc/{{ blockchain_id }}/rpc"
+blockscout_rpc: "http://{{ hostvars['validator01'].ansible_host }}:9650/ext/bc/{{ blockscout_blockchain_id }}/rpc"
 blockscout_env_vars:
   CHAIN_ID: 66666

--- a/inventories/local/group_vars/faucet.yml
+++ b/inventories/local/group_vars/faucet.yml
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2023, E36 Knots
 ---
-blockchain_id: 2dEmExGjJT6MouJRr1PqV4PSQEbScDAjKuPtT6pgqYR5xdUuac
+faucet_blockchain_id: 2dEmExGjJT6MouJRr1PqV4PSQEbScDAjKuPtT6pgqYR5xdUuac
 
 avalanche_faucet_evmchains:
   - ID: ASH
     NAME: AshLocalEVM
     TOKEN: ASH
-    RPC: "http://{{ hostvars['validator01'].ansible_host }}:9650/ext/bc/{{ blockchain_id }}/rpc"
+    RPC: "http://{{ hostvars['validator01'].ansible_host }}:9650/ext/bc/{{ faucet_blockchain_id }}/rpc"
     CHAINID: 66666
     EXPLORER: "http://{{ hostvars['frontend'].ansible_host }}:4000"
     IMAGE: https://ash.center/img/ash-logo.svg

--- a/inventories/local/group_vars/subnet_txs_host.yml
+++ b/inventories/local/group_vars/subnet_txs_host.yml
@@ -45,3 +45,11 @@ subnet_blockchains_list:
 # Private key of the pre-funded account
 subnet_txs_private_key: PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN
 subnet_txs_key_encoding: cb58
+
+# Validators to be added to the Subnet
+subnet_validators_params:
+  - node_id: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
+    start_time: "{{ subnet_validator_start_time }}"
+    end_time: "{{ subnet_validator_end_time }}"
+    stake_or_weight: 100
+    delegation_fee: 2


### PR DESCRIPTION
### Dependencies

- https://github.com/AshAvalanche/ansible-avalanche-collection/pull/88

### Changes

- Remove custom consensus parameters
- Set validator weight to `100`
- Add an example of how to use the new `subnet_validator_params` variable