### PR TITLE
feat: Docker Avalanche nodes for local network

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ The complete documentation related to this project starts by the [Local Test Net
    ```bash
    ansible-playbook ash.avalanche.bootstrap_local_network -i inventories/local
    ```
+
+## Docker Compose
+
+It is possible to build Docker images for the Avalanche nodes using [Packer](https://developer.hashicorp.com/packer) and run them using Docker Compose. See [docker/README.md](./docker/README.md) for more information.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,85 @@
+# Local Avalanche Test Network with Docker
+
+For some use cases, it can be useful to pre-build Docker images and run the local Avalanche test network using Docker Compose.
+
+## Requirements
+
+- [Docker](https://docs.docker.com) installed (see [Get Docker](https://docs.docker.com/get-docker/))
+- [Packer](https://developer.hashicorp.com/packer) installed (see [Install Packer](https://developer.hashicorp.com/packer/downloads))
+- [Ansible](https://docs.ansible.com/ansible) installed (see [Installing Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html))
+- The `ash.avalanche` collection installed (see [Setup the environment](../README.md#setup-the-environment))
+- The Avalanche VM to install has to be specified by enriching the `avalanchego_vms_list` variable in [../inventories/local/avalanche_nodes.yml](../inventories/local/avalanche_nodes.yml). Example:
+
+  ```yaml
+  avalanchego_vms_list:
+    ash-subnet-evm:
+      download_url: https://github.com/AshAvalanche/subnet-evm/releases/download
+      id: jvFWMths2qLjsZgbyEKx82PkQv2YWR4rotjQfxV55vLLogjNA
+      # Used in Ash CLI
+      ash_vm_type: Custom
+      aliases:
+        - ash-subnet-evm
+      versions_comp:
+        0.666.0:
+          ge: 1.10.5
+          le: 1.10.8
+  ```
+
+## Build the Docker images
+
+The `avalanche-node-*.pkr.hcl` Packer templates allow to build Docker images for the 5 Avalanche nodes of the `local` network with:
+
+- 1 fixed version of AvalancheGo
+- 1 fixed version of an Avalanche VM
+
+Out of simplicity, the `build.sh` script is provided:
+
+```bash
+cd docker
+
+# Set the AvalancheGo version
+export AVALANCHEGO_VERSION=1.10.9
+# Set the Avalanche VM to install with its version
+export AVALANCHEGO_VM_NAME=subnet-evm
+export AVALANCHEGO_VM_VERSION=0.5.6
+
+./build.sh
+```
+
+The build will publish the following Docker images to the local Docker registry:
+
+```bash
+$ docker image ls
+REPOSITORY                            TAG                      IMAGE ID      CREATED            SIZE
+ash/avalanche-node-local-validator05  1.10.9-subnet-evm-0.5.6  810187bfeb08  About an hour ago  368MB
+ash/avalanche-node-local-validator04  1.10.9-subnet-evm-0.5.6  fe05a65bb297  About an hour ago  368MB
+ash/avalanche-node-local-validator03  1.10.9-subnet-evm-0.5.6  52f16e544a21  About an hour ago  368MB
+ash/avalanche-node-local-validator02  1.10.9-subnet-evm-0.5.6  ac9e3f3b88af  About an hour ago  368MB
+ash/avalanche-node-local-validator01  1.10.9-subnet-evm-0.5.6  8c101af0e369  About an hour ago  368MB
+ash/avalanche-node                    1.10.9-subnet-evm-0.5.6  4fe58ef61de4  About an hour ago  368MB
+```
+
+## Start the local Avalanche test network with Docker Compose
+
+To start the local Avalanche test network with Docker Compose, simply run `docker-compose up -d`.
+
+## Creating a local Subnet
+
+To create a local Subnet, you can use the same playbook as for the Multipass-based local test network:
+
+```bash
+ansible-playbook ash.avalanche.create_subnet -i inventories/local
+```
+
+To track the newly created Subnet, restart the Docker containers after exporting the `SUBNET_ID` (prompted at the end of the playbook):
+
+```bash
+export SUBNET_ID=$NEW_SUBNET_ID
+docker-compose restart
+```
+
+## Using the Ash CLI
+
+```bash
+docker exec -t ash-avalanche-local-validator01 ash avalanche subnet list
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -61,21 +61,26 @@ ash/avalanche-node                    1.10.9-subnet-evm-0.5.6  4fe58ef61de4  Abo
 
 ## Start the local Avalanche test network with Docker Compose
 
-To start the local Avalanche test network with Docker Compose, simply run `docker-compose up -d`.
+To start the local Avalanche test network with Docker Compose, simply run `docker compose up -d`.
 
 ## Creating a local Subnet
 
 To create a local Subnet, you can use the same playbook as for the Multipass-based local test network:
 
 ```bash
+# Note: you may have to wait a few seconds for the network to be bootstrapped and ready
+
 ansible-playbook ash.avalanche.create_subnet -i inventories/local
 ```
 
-To track the newly created Subnet, restart the Docker containers after exporting the `SUBNET_ID` (prompted at the end of the playbook):
+To track the newly created Subnet, restart the Docker containers after adding the Subnet ID to the `track-subnets` configuration parameter of the Avalanche nodes:
 
 ```bash
-export SUBNET_ID=$NEW_SUBNET_ID
-docker-compose restart
+for v in {1..5}; do
+  sed -i 's/"track-subnets": ".*"/"track-subnets": "29uVeLPJB1eQJkzRemU8g8wZDw5uJRqpab5U2mX9euieVwiEbL"/' "data/conf/validator0$v/conf/node.json";
+done
+
+docker compose restart
 ```
 
 ## Using the Ash CLI

--- a/docker/ansible.cfg
+++ b/docker/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+host_key_checking = False
+collections_paths = ..
+roles_path = ../ansible_roles
+stdout_callback = yaml
+hash_behaviour = merge

--- a/docker/avalanche-node-docker.pkr.hcl
+++ b/docker/avalanche-node-docker.pkr.hcl
@@ -1,0 +1,75 @@
+packer {
+  required_plugins {
+    docker = {
+      version = ">= 1.0.1"
+      source  = "github.com/hashicorp/docker"
+    }
+    ansible = {
+      version = ">= 1.1.0"
+      source  = "github.com/hashicorp/ansible"
+    }
+  }
+}
+
+variable "avalanchego_version" {
+  type    = string
+  default = "1.10.9"
+}
+
+variable "avalanchego_vm_name" {
+  type    = string
+  default = "subnet-evm"
+}
+
+variable "avalanchego_vm_version" {
+  type    = string
+  default = "0.5.6"
+}
+
+source "docker" "ubuntu" {
+  image  = "ubuntu:22.04"
+  commit = true
+}
+
+build {
+  name = "avalanche-node-${var.avalanchego_version}-${var.avalanchego_vm_name}-${var.avalanchego_vm_version}"
+  sources = [
+    "source.docker.ubuntu"
+  ]
+
+  provisioner "shell" {
+    inline = [
+      "apt-get update",
+      "apt-get install -y ca-certificates gpg python3 sudo",
+    ]
+  }
+
+  provisioner "ansible" {
+    ansible_env_vars = [
+      "ANSIBLE_CONFIG=../ansible.cfg",
+      "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
+    ]
+    inventory_directory = "../inventories/local"
+    host_alias          = "avalanche_node"
+    groups = [
+      "avalanche_nodes",
+      "bootstrap_nodes"
+    ]
+    playbook_file = "../ansible_collections/ash/avalanche/playbooks/provision_nodes.yml"
+    extra_arguments = [
+      "--tags",
+      "install-avalanchego,install-vms,install-ash_cli",
+      "--extra-vars",
+      "{avalanchego_auto_restart: false}",
+      "--extra-vars",
+      "{avalanchego_version: ${var.avalanchego_version}}",
+      "--extra-vars",
+      "{avalanchego_vms_install: ['${var.avalanchego_vm_name}=${var.avalanchego_vm_version}']}"
+    ]
+  }
+
+  post-processor "docker-tag" {
+    repository = "ash/avalanche-node"
+    tags       = ["${var.avalanchego_version}-${var.avalanchego_vm_name}-${var.avalanchego_vm_version}"]
+  }
+}

--- a/docker/avalanche-node-local-docker.pkr.hcl
+++ b/docker/avalanche-node-local-docker.pkr.hcl
@@ -1,0 +1,85 @@
+packer {
+  required_plugins {
+    docker = {
+      version = ">= 1.0.1"
+      source  = "github.com/hashicorp/docker"
+    }
+    ansible = {
+      version = ">= 1.1.0"
+      source  = "github.com/hashicorp/ansible"
+    }
+  }
+}
+
+variable "avalanchego_version" {
+  type    = string
+  default = "1.10.9"
+}
+
+variable "avalanchego_vm_name" {
+  type    = string
+  default = "subnet-evm"
+}
+
+variable "avalanchego_vm_version" {
+  type    = string
+  default = "0.5.6"
+}
+
+variable "avalanche_node_name" {
+  type    = string
+  default = "validator01"
+}
+
+variable "avalanche_node_groups" {
+  type = list(string)
+  default = [
+    "avalanche_nodes",
+    "bootstrap_nodes",
+  ]
+}
+
+source "docker" "avalanche_node" {
+  image  = "ash/avalanche-node:${var.avalanchego_version}-${var.avalanchego_vm_name}-${var.avalanchego_vm_version}"
+  pull   = false
+  commit = true
+  changes = [
+    "ENV BOOTSTRAP_ID ''",
+    "ENV BOOTSTRAP_IP ''",
+    "ENV SUBNET_ID ''",
+    "ENTRYPOINT /opt/avalanche/avalanchego/current/avalanchego --plugin-dir=/opt/avalanche/avalanchego/current/plugins --config-file=/etc/avalanche/avalanchego/conf/node.json --bootstrap-ids=\"$BOOTSTRAP_ID\" --bootstrap-ips=\"$BOOTSTRAP_IP\" --track-subnets=\"$SUBNET_ID\""
+  ]
+}
+
+build {
+  name = "avalanche-node-local-${var.avalanche_node_name}"
+  sources = [
+    "source.docker.avalanche_node"
+  ]
+
+  provisioner "ansible" {
+    ansible_env_vars = [
+      "ANSIBLE_CONFIG=../ansible.cfg",
+      "SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt"
+    ]
+    inventory_directory = "../inventories/local"
+    host_alias          = "${var.avalanche_node_name}"
+    groups              = var.avalanche_node_groups
+    playbook_file       = "../ansible_collections/ash/avalanche/playbooks/provision_nodes.yml"
+    extra_arguments = [
+      "--tags",
+      "config-avalanchego,config-subnets,config-chains,config-ash_cli",
+      "--extra-vars",
+      "{avalanchego_auto_restart: false, avalanchego_public_ip: ''}",
+      "--extra-vars",
+      "{avalanchego_version: ${var.avalanchego_version}}",
+      "--extra-vars",
+      "{avalanchego_vms_install: ['${var.avalanchego_vm_name}=${var.avalanchego_vm_version}']}"
+    ]
+  }
+
+  post-processor "docker-tag" {
+    repository = "ash/avalanche-node-local-${var.avalanche_node_name}"
+    tags       = ["${var.avalanchego_version}-${var.avalanchego_vm_name}-${var.avalanchego_vm_version}"]
+  }
+}

--- a/docker/avalanche-node-local-docker.pkr.hcl
+++ b/docker/avalanche-node-local-docker.pkr.hcl
@@ -44,10 +44,7 @@ source "docker" "avalanche_node" {
   pull   = false
   commit = true
   changes = [
-    "ENV BOOTSTRAP_ID ''",
-    "ENV BOOTSTRAP_IP ''",
-    "ENV SUBNET_ID ''",
-    "ENTRYPOINT /opt/avalanche/avalanchego/current/avalanchego --plugin-dir=/opt/avalanche/avalanchego/current/plugins --config-file=/etc/avalanche/avalanchego/conf/node.json --bootstrap-ids=\"$BOOTSTRAP_ID\" --bootstrap-ips=\"$BOOTSTRAP_IP\" --track-subnets=\"$SUBNET_ID\""
+    "ENTRYPOINT /opt/avalanche/avalanchego/current/avalanchego --plugin-dir=/opt/avalanche/avalanchego/current/plugins --config-file=/etc/avalanche/avalanchego/mounted-conf/node.json"
   ]
 }
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -16,6 +16,9 @@ AVALANCHEGO_VERSION=${AVALANCHEGO_VERSION:-1.10.9}
 AVALANCHEGO_VM_NAME=${AVALANCHEGO_VM_NAME:-subnet-evm}
 AVALANCHEGO_VM_VERSION=${AVALANCHEGO_VM_VERSION:-0.5.6}
 
+# Init Packer
+packer init avalanche-node-docker.pkr.hcl
+
 # Build the Avalanche node base image
 packer build -var "avalanchego_version=${AVALANCHEGO_VERSION}" \
 	-var "avalanchego_vm_name=${AVALANCHEGO_VM_NAME}" \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Build local Avalanche nodes Docker images using Packer
+# The images are tagged with the AvalancheGo version, VM name and VM version
+# The images are pushed to the local Docker registry
+# Usage: ./build.sh
+# Environment variables:
+# - AVALANCHEGO_VERSION: the AvalancheGo version to build (default: 1.10.9)
+# - AVALANCHEGO_VM_NAME: the name of the blockchain VM to install on the node (default: subnet-evm)
+# - AVALANCHEGO_VM_VERSION: the version of the blockchain VM to install on the node (default: 0.5.6)
+
+set -euo pipefail
+
+# Set default values for environment variables
+AVALANCHEGO_VERSION=${AVALANCHEGO_VERSION:-1.10.9}
+AVALANCHEGO_VM_NAME=${AVALANCHEGO_VM_NAME:-subnet-evm}
+AVALANCHEGO_VM_VERSION=${AVALANCHEGO_VM_VERSION:-0.5.6}
+
+# Build the Avalanche node base image
+packer build -var "avalanchego_version=${AVALANCHEGO_VERSION}" \
+	-var "avalanchego_vm_name=${AVALANCHEGO_VM_NAME}" \
+	-var "avalanchego_vm_version=${AVALANCHEGO_VM_VERSION}" \
+	avalanche-node-docker.pkr.hcl
+
+# Build the local Avalanche nodes images
+for v in {1..5}; do
+	packer build -var "avalanchego_version=${AVALANCHEGO_VERSION}" \
+		-var "avalanchego_vm_name=${AVALANCHEGO_VM_NAME}" \
+		-var "avalanchego_vm_version=${AVALANCHEGO_VM_VERSION}" \
+		-var "avalanche_node_name=validator0${v}" \
+		avalanche-node-local-docker.pkr.hcl
+done

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -15,7 +15,7 @@ services:
       avalanchelocal:
         ipv4_address: 177.17.0.11
     environment:
-      SUBNET_ID: "${SUBNET_ID:-''}"
+      SUBNET_ID: "${SUBNET_ID:-}"
   avalanche-local-validator02:
     image: "ash/avalanche-node-local-validator02:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
     container_name: ash-avalanche-local-validator02
@@ -28,7 +28,7 @@ services:
     environment:
       BOOTSTRAP_ID: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
       BOOTSTRAP_IP: 177.17.0.11:9651
-      SUBNET_ID: "${SUBNET_ID:-''}"
+      SUBNET_ID: "${SUBNET_ID:-}"
   avalanche-local-validator03:
     image: "ash/avalanche-node-local-validator03:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
     container_name: ash-avalanche-local-validator03
@@ -41,7 +41,7 @@ services:
     environment:
       BOOTSTRAP_ID: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
       BOOTSTRAP_IP: 177.17.0.11:9651
-      SUBNET_ID: "${SUBNET_ID:-''}"
+      SUBNET_ID: "${SUBNET_ID:-}"
   avalanche-local-validator04:
     image: "ash/avalanche-node-local-validator04:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
     container_name: ash-avalanche-local-validator04
@@ -54,7 +54,7 @@ services:
     environment:
       BOOTSTRAP_ID: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
       BOOTSTRAP_IP: 177.17.0.11:9651
-      SUBNET_ID: "${SUBNET_ID:-''}"
+      SUBNET_ID: "${SUBNET_ID:-}"
   avalanche-local-validator05:
     image: "ash/avalanche-node-local-validator05:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
     container_name: ash-avalanche-local-validator05
@@ -67,4 +67,4 @@ services:
     environment:
       BOOTSTRAP_ID: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
       BOOTSTRAP_IP: 177.17.0.11:9651
-      SUBNET_ID: "${SUBNET_ID:-''}"
+      SUBNET_ID: "${SUBNET_ID:-}"

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,70 @@
+networks:
+  avalanchelocal:
+    ipam:
+      driver: default
+      config:
+        - subnet: 177.17.0.0/24
+services:
+  avalanche-local-validator01:
+    image: "ash/avalanche-node-local-validator01:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
+    container_name: ash-avalanche-local-validator01
+    ports:
+      - "9650:9650"
+      - "9651:9651"
+    networks:
+      avalanchelocal:
+        ipv4_address: 177.17.0.11
+    environment:
+      SUBNET_ID: "${SUBNET_ID:-''}"
+  avalanche-local-validator02:
+    image: "ash/avalanche-node-local-validator02:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
+    container_name: ash-avalanche-local-validator02
+    ports:
+      - "9652:9650"
+      - "9653:9651"
+    networks:
+      avalanchelocal:
+        ipv4_address: 177.17.0.12
+    environment:
+      BOOTSTRAP_ID: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
+      BOOTSTRAP_IP: 177.17.0.11:9651
+      SUBNET_ID: "${SUBNET_ID:-''}"
+  avalanche-local-validator03:
+    image: "ash/avalanche-node-local-validator03:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
+    container_name: ash-avalanche-local-validator03
+    ports:
+      - "9654:9650"
+      - "9655:9651"
+    networks:
+      avalanchelocal:
+        ipv4_address: 177.17.0.13
+    environment:
+      BOOTSTRAP_ID: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
+      BOOTSTRAP_IP: 177.17.0.11:9651
+      SUBNET_ID: "${SUBNET_ID:-''}"
+  avalanche-local-validator04:
+    image: "ash/avalanche-node-local-validator04:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
+    container_name: ash-avalanche-local-validator04
+    ports:
+      - "9656:9650"
+      - "9657:9651"
+    networks:
+      avalanchelocal:
+        ipv4_address: 177.17.0.14
+    environment:
+      BOOTSTRAP_ID: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
+      BOOTSTRAP_IP: 177.17.0.11:9651
+      SUBNET_ID: "${SUBNET_ID:-''}"
+  avalanche-local-validator05:
+    image: "ash/avalanche-node-local-validator05:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
+    container_name: ash-avalanche-local-validator05
+    ports:
+      - "9658:9650"
+      - "9659:9651"
+    networks:
+      avalanchelocal:
+        ipv4_address: 177.17.0.15
+    environment:
+      BOOTSTRAP_ID: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
+      BOOTSTRAP_IP: 177.17.0.11:9651
+      SUBNET_ID: "${SUBNET_ID:-''}"

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -14,8 +14,8 @@ services:
     networks:
       avalanchelocal:
         ipv4_address: 177.17.0.11
-    environment:
-      SUBNET_ID: "${SUBNET_ID:-}"
+    volumes:
+      - ./data/conf/validator01/conf:/etc/avalanche/avalanchego/mounted-conf
   avalanche-local-validator02:
     image: "ash/avalanche-node-local-validator02:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
     container_name: ash-avalanche-local-validator02
@@ -25,10 +25,8 @@ services:
     networks:
       avalanchelocal:
         ipv4_address: 177.17.0.12
-    environment:
-      BOOTSTRAP_ID: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
-      BOOTSTRAP_IP: 177.17.0.11:9651
-      SUBNET_ID: "${SUBNET_ID:-}"
+    volumes:
+      - ./data/conf/validator02/conf:/etc/avalanche/avalanchego/mounted-conf
   avalanche-local-validator03:
     image: "ash/avalanche-node-local-validator03:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
     container_name: ash-avalanche-local-validator03
@@ -38,10 +36,8 @@ services:
     networks:
       avalanchelocal:
         ipv4_address: 177.17.0.13
-    environment:
-      BOOTSTRAP_ID: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
-      BOOTSTRAP_IP: 177.17.0.11:9651
-      SUBNET_ID: "${SUBNET_ID:-}"
+    volumes:
+      - ./data/conf/validator03/conf:/etc/avalanche/avalanchego/mounted-conf
   avalanche-local-validator04:
     image: "ash/avalanche-node-local-validator04:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
     container_name: ash-avalanche-local-validator04
@@ -51,10 +47,8 @@ services:
     networks:
       avalanchelocal:
         ipv4_address: 177.17.0.14
-    environment:
-      BOOTSTRAP_ID: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
-      BOOTSTRAP_IP: 177.17.0.11:9651
-      SUBNET_ID: "${SUBNET_ID:-}"
+    volumes:
+      - ./data/conf/validator04/conf:/etc/avalanche/avalanchego/mounted-conf
   avalanche-local-validator05:
     image: "ash/avalanche-node-local-validator05:${AVALANCHEGO_VERSION:-1.10.9}-${AVALANCHEGO_VM_NAME:-subnet-evm}-${AVALANCHEGO_VM_VERSION:-0.5.6}"
     container_name: ash-avalanche-local-validator05
@@ -64,7 +58,5 @@ services:
     networks:
       avalanchelocal:
         ipv4_address: 177.17.0.15
-    environment:
-      BOOTSTRAP_ID: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
-      BOOTSTRAP_IP: 177.17.0.11:9651
-      SUBNET_ID: "${SUBNET_ID:-}"
+    volumes:
+      - ./data/conf/validator05/conf:/etc/avalanche/avalanchego/mounted-conf

--- a/docker/data/conf/validator01/conf/node.json
+++ b/docker/data/conf/validator01/conf/node.json
@@ -1,0 +1,23 @@
+{
+  "bootstrap-ids": "",
+  "bootstrap-ips": "",
+  "chain-aliases-file": "/etc/avalanche/avalanchego/conf/chains/aliases.json",
+  "chain-config-dir": "/etc/avalanche/avalanchego/conf/chains",
+  "db-dir": "/var/lib/avalanchego/db",
+  "http-allowed-hosts": "*",
+  "http-host": "0.0.0.0",
+  "http-port": 9650,
+  "http-tls-enabled": false,
+  "log-dir": "/var/log/avalanche/avalanchego",
+  "log-level": "info",
+  "network-id": "local",
+  "public-ip": "",
+  "snow-quorum-size": 15,
+  "snow-sample-size": 20,
+  "staking-port": 9651,
+  "staking-tls-cert-file": "/etc/avalanche/avalanchego/staking/validator01.crt",
+  "staking-tls-key-file": "/etc/avalanche/avalanchego/staking/validator01.key",
+  "subnet-config-dir": "/etc/avalanche/avalanchego/conf/subnets",
+  "track-subnets": "29uVeLPJB1eQJkzRemU8g8wZDw5uJRqpab5U2mX9euieVwiEbL",
+  "vm-aliases-file": "/etc/avalanche/avalanchego/conf/vms/aliases.json"
+}

--- a/docker/data/conf/validator02/conf/node.json
+++ b/docker/data/conf/validator02/conf/node.json
@@ -1,0 +1,23 @@
+{
+  "bootstrap-ids": "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg",
+  "bootstrap-ips": "177.17.0.11:9651",
+  "chain-aliases-file": "/etc/avalanche/avalanchego/conf/chains/aliases.json",
+  "chain-config-dir": "/etc/avalanche/avalanchego/conf/chains",
+  "db-dir": "/var/lib/avalanchego/db",
+  "http-allowed-hosts": "*",
+  "http-host": "0.0.0.0",
+  "http-port": 9650,
+  "http-tls-enabled": false,
+  "log-dir": "/var/log/avalanche/avalanchego",
+  "log-level": "info",
+  "network-id": "local",
+  "public-ip": "",
+  "snow-quorum-size": 15,
+  "snow-sample-size": 20,
+  "staking-port": 9651,
+  "staking-tls-cert-file": "/etc/avalanche/avalanchego/staking/validator02.crt",
+  "staking-tls-key-file": "/etc/avalanche/avalanchego/staking/validator02.key",
+  "subnet-config-dir": "/etc/avalanche/avalanchego/conf/subnets",
+  "track-subnets": "29uVeLPJB1eQJkzRemU8g8wZDw5uJRqpab5U2mX9euieVwiEbL",
+  "vm-aliases-file": "/etc/avalanche/avalanchego/conf/vms/aliases.json"
+}

--- a/docker/data/conf/validator03/conf/node.json
+++ b/docker/data/conf/validator03/conf/node.json
@@ -1,0 +1,23 @@
+{
+  "bootstrap-ids": "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg",
+  "bootstrap-ips": "177.17.0.11:9651",
+  "chain-aliases-file": "/etc/avalanche/avalanchego/conf/chains/aliases.json",
+  "chain-config-dir": "/etc/avalanche/avalanchego/conf/chains",
+  "db-dir": "/var/lib/avalanchego/db",
+  "http-allowed-hosts": "*",
+  "http-host": "0.0.0.0",
+  "http-port": 9650,
+  "http-tls-enabled": false,
+  "log-dir": "/var/log/avalanche/avalanchego",
+  "log-level": "info",
+  "network-id": "local",
+  "public-ip": "",
+  "snow-quorum-size": 15,
+  "snow-sample-size": 20,
+  "staking-port": 9651,
+  "staking-tls-cert-file": "/etc/avalanche/avalanchego/staking/validator03.crt",
+  "staking-tls-key-file": "/etc/avalanche/avalanchego/staking/validator03.key",
+  "subnet-config-dir": "/etc/avalanche/avalanchego/conf/subnets",
+  "track-subnets": "29uVeLPJB1eQJkzRemU8g8wZDw5uJRqpab5U2mX9euieVwiEbL",
+  "vm-aliases-file": "/etc/avalanche/avalanchego/conf/vms/aliases.json"
+}

--- a/docker/data/conf/validator04/conf/node.json
+++ b/docker/data/conf/validator04/conf/node.json
@@ -1,0 +1,23 @@
+{
+  "bootstrap-ids": "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg",
+  "bootstrap-ips": "177.17.0.11:9651",
+  "chain-aliases-file": "/etc/avalanche/avalanchego/conf/chains/aliases.json",
+  "chain-config-dir": "/etc/avalanche/avalanchego/conf/chains",
+  "db-dir": "/var/lib/avalanchego/db",
+  "http-allowed-hosts": "*",
+  "http-host": "0.0.0.0",
+  "http-port": 9650,
+  "http-tls-enabled": false,
+  "log-dir": "/var/log/avalanche/avalanchego",
+  "log-level": "info",
+  "network-id": "local",
+  "public-ip": "",
+  "snow-quorum-size": 15,
+  "snow-sample-size": 20,
+  "staking-port": 9651,
+  "staking-tls-cert-file": "/etc/avalanche/avalanchego/staking/validator04.crt",
+  "staking-tls-key-file": "/etc/avalanche/avalanchego/staking/validator04.key",
+  "subnet-config-dir": "/etc/avalanche/avalanchego/conf/subnets",
+  "track-subnets": "29uVeLPJB1eQJkzRemU8g8wZDw5uJRqpab5U2mX9euieVwiEbL",
+  "vm-aliases-file": "/etc/avalanche/avalanchego/conf/vms/aliases.json"
+}

--- a/docker/data/conf/validator05/conf/node.json
+++ b/docker/data/conf/validator05/conf/node.json
@@ -1,0 +1,23 @@
+{
+  "bootstrap-ids": "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg",
+  "bootstrap-ips": "177.17.0.11:9651",
+  "chain-aliases-file": "/etc/avalanche/avalanchego/conf/chains/aliases.json",
+  "chain-config-dir": "/etc/avalanche/avalanchego/conf/chains",
+  "db-dir": "/var/lib/avalanchego/db",
+  "http-allowed-hosts": "*",
+  "http-host": "0.0.0.0",
+  "http-port": 9650,
+  "http-tls-enabled": false,
+  "log-dir": "/var/log/avalanche/avalanchego",
+  "log-level": "info",
+  "network-id": "local",
+  "public-ip": "",
+  "snow-quorum-size": 15,
+  "snow-sample-size": 20,
+  "staking-port": 9651,
+  "staking-tls-cert-file": "/etc/avalanche/avalanchego/staking/validator05.crt",
+  "staking-tls-key-file": "/etc/avalanche/avalanchego/staking/validator05.key",
+  "subnet-config-dir": "/etc/avalanche/avalanchego/conf/subnets",
+  "track-subnets": "29uVeLPJB1eQJkzRemU8g8wZDw5uJRqpab5U2mX9euieVwiEbL",
+  "vm-aliases-file": "/etc/avalanche/avalanchego/conf/vms/aliases.json"
+}

--- a/docker/inventories/local/group_vars
+++ b/docker/inventories/local/group_vars
@@ -1,0 +1,1 @@
+../../../inventories/local/group_vars

--- a/docker/inventories/local/hosts
+++ b/docker/inventories/local/hosts
@@ -1,0 +1,14 @@
+validator01 ansible_connection=docker ansible_host=ash-avalanche-local-validator01
+validator02 ansible_connection=docker ansible_host=ash-avalanche-local-validator02
+validator03 ansible_connection=docker ansible_host=ash-avalanche-local-validator03
+validator04 ansible_connection=docker ansible_host=ash-avalanche-local-validator04
+validator05 ansible_connection=docker ansible_host=ash-avalanche-local-validator05
+
+[avalanche_nodes]
+validator0[1:5]
+
+[subnet_txs_host]
+validator01
+
+[subnet_validators]
+validator0[1:5]


### PR DESCRIPTION
Pretty cool metrics:

|                               |       |
| ----------------------------- | ----- |
| Docker images build           | 2m |
| Docker compose up             | 0.1s  |
| `ash.avalanche.create_subnet` | 50s   |
| Docker compose restart        | 12s   |
| **Zero to Subnet** | **3m** |
|**Zero to Subnet pre-built** | **1m** |

See [docker/README.md](https://github.com/AshAvalanche/ansible-avalanche-getting-started/blob/6d0f36c5311caeca2df0d48f1026fb308683f815/docker/README.md) for more details.

### Dependencies

- https://github.com/AshAvalanche/ansible-avalanche-collection/pull/99

### Changes

- Add Packer templates, Docker compose config, and updated Ansible inventory for a local Docker network in `docker/`
  - Packer templates:
    - `avalanche-node-docker.pkr.hcl` builds a base image for a given AvalancheGo version + a custom Avalanche VM (and version)
    - `avalanche-node-local-docker.pkr.hcl` builds a local Avalanche node (`validator0[1:5]`) with notably the right TLS key and certificate
  - `compose.yml` allows provisioning the 5 local Avalanche nodes with `validator01` as the bootstrap node
  - The inventory `inventories/local` can be used to create Subnets with the `ash.avalanche` Ansible collection

### Additional comments

- The `build.sh` script is provided to ease the build
- We leverage the [Packer Ansible plugin](https://developer.hashicorp.com/packer/integrations/hashicorp/ansible) to build the Docker images with the `ash.avalanche` collection
- The containers are started on the `avalanchelocal` Docker network in the `177.17.0.0/24` subnet