### PR TITLE
feat(infra) Add nginx docker container to terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ ansible_roles
 terraform.tfstate*
 files/ansible_key.pem
 hosts.ini
-local-test-network.yml
+terraform/multipass/nginx.conf

--- a/terraform/multipass/local-test-network.yml
+++ b/terraform/multipass/local-test-network.yml
@@ -8,8 +8,8 @@ avalancheNetworks:
             name: P-Chain
             vmID: 11111111111111111111111111111111LpoYY
             vmType: PlatformVM
-            rpcUrl: http://${validators[0].ipv4}:9650/ext/bc/P
+            rpcUrl: http://127.0.0.1/ext/bc/P
           - name: X-Chain
             vmID: jvYyfQTxGMJLuGWa55kdP2p2zSUYsQ5Raupu4TW34ZAUBAbtq
             vmType: AvalancheVM
-            rpcUrl: http://${validators[0].ipv4}:9650/ext/bc/X
+            rpcUrl: http://127.0.0.1/ext/bc/X

--- a/terraform/multipass/main.tf
+++ b/terraform/multipass/main.tf
@@ -78,10 +78,10 @@ output "frontend_ip" {
   value = data.multipass_instance.frontend_info.ipv4
 }
 
-# docker
+# Docker
 provider "docker" {}
 
-# writing configuration using template file
+# NGINX configuration templating
 resource "local_file" "nginx_conf" {
   content  = templatefile(
     "nginx.tftpl",
@@ -92,13 +92,13 @@ resource "local_file" "nginx_conf" {
   filename = abspath("nginx.conf")
 }
 
-# docker image
+# NGINX Docker image
 resource "docker_image" "nginx" {
   name         = "nginx:1.25.3"
   keep_locally = true
 }
 
-# docker container
+# NGINX Docker container
 resource "docker_container" "nginx" {
   image = docker_image.nginx.image_id
   name  = "avax_nginx"

--- a/terraform/multipass/main.tf
+++ b/terraform/multipass/main.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "larstobi/multipass"
       version = "1.4.2"
     }
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.0.2"
+    }
   }
 }
 
@@ -65,17 +69,6 @@ resource "local_file" "ansible_hosts" {
   filename = "hosts.ini"
 }
 
-# Ash CLI configuration templating
-resource "local_file" "ash_cli_config" {
-  content = templatefile(
-    "local-test-network.tftpl",
-    {
-      validators = values(data.multipass_instance.validators_info)
-    }
-  )
-  filename = "local-test-network.yml"
-}
-
 # Outputs
 output "validators_ips" {
   value = values(data.multipass_instance.validators_info).*.ipv4
@@ -83,4 +76,39 @@ output "validators_ips" {
 
 output "frontend_ip" {
   value = data.multipass_instance.frontend_info.ipv4
+}
+
+# docker
+provider "docker" {}
+
+# writing configuration using template file
+resource "local_file" "nginx_conf" {
+  content  = templatefile(
+    "nginx.tftpl",
+    {
+      validators = values(data.multipass_instance.validators_info)
+    }
+  )
+  filename = abspath("nginx.conf")
+}
+
+# docker image
+resource "docker_image" "nginx" {
+  name         = "nginx:1.25.3"
+  keep_locally = true
+}
+
+# docker container
+resource "docker_container" "nginx" {
+  image = docker_image.nginx.image_id
+  name  = "avax_nginx"
+  ports {
+    internal = 80
+    external = 80
+  }
+  mounts {
+    target = "/etc/nginx/nginx.conf"
+    type   = "bind"
+    source = local_file.nginx_conf.filename
+  }
 }

--- a/terraform/multipass/nginx.tftpl
+++ b/terraform/multipass/nginx.tftpl
@@ -1,0 +1,19 @@
+worker_processes 1;# Core count
+events {
+    worker_connections  1024;# Connections per sec per core
+}
+
+http {
+    upstream avax {
+        %{ for ip in validators[*].ipv4 ~}
+        server ${ip}:9650;
+        %{ endfor ~}
+    }
+    server {
+        listen 80;
+
+        location / {
+            proxy_pass http://avax;
+        }
+    }
+}


### PR DESCRIPTION
### Linked issues

- Feat #42 

### Changes

- Add kreuzwerker/docker v3.0.2 in terraform providers
- Download and deploy nginx v1.25.3 container using the port 80

### Breaking changes

- As rpc requests are load balanced between nodes, they are exposed through 127.0.0.1
